### PR TITLE
Adding permissions tag for Github Actions workflows

### DIFF
--- a/.github/workflows/docker-image-dev.yml
+++ b/.github/workflows/docker-image-dev.yml
@@ -2,6 +2,9 @@ on:
   push:
     branches: dev
 
+permissions:
+  contents: read
+
 jobs:
   main:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,6 +1,10 @@
 on:
   workflow_dispatch:
 
+permissions:
+  # Write permission needed for creating a tag.
+  contents: write
+
 jobs:
   main:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -3,6 +3,9 @@
 
 name: Upload Python Package
 
+permissions:
+  contents: read
+
 on:
   release:
     types: [created]

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -3,12 +3,12 @@
 
 name: Upload Python Package
 
-permissions:
-  contents: read
-
 on:
   release:
     types: [created]
+
+permissions:
+  contents: read
 
 jobs:
   deploy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,9 @@ name: Unit Tests
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
 


### PR DESCRIPTION
Setting proper permissions for `GITHUB_TOKEN` in the workflows according to https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/.

All is needed is calling `actions/checkout`, so `contents: read` is enough, except for `docker-image.yml` which needs tagging permission, so `contens: write`.