### PR TITLE
CM-24629 - Lock urllib3 v1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -91,13 +91,13 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "certifi"
-version = "2023.5.7"
+version = "2023.7.22"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "certifi-2023.5.7-py3-none-any.whl", hash = "sha256:c6c2e98f5c7869efca1f8916fed228dd91539f9f1b444c314c06eef02980c716"},
-    {file = "certifi-2023.5.7.tar.gz", hash = "sha256:0f0d56dc5a6ad56fd4ba36484d6cc34451e1c6548c61daad8c320169f91eddc7"},
+    {file = "certifi-2023.7.22-py3-none-any.whl", hash = "sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9"},
+    {file = "certifi-2023.7.22.tar.gz", hash = "sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082"},
 ]
 
 [[package]]

--- a/poetry.lock
+++ b/poetry.lock
@@ -872,20 +872,19 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.0.2"
+version = "1.26.16"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 files = [
-    {file = "urllib3-2.0.2-py3-none-any.whl", hash = "sha256:d055c2f9d38dc53c808f6fdc8eab7360b6fdbbde02340ed25cfbcd817c62469e"},
-    {file = "urllib3-2.0.2.tar.gz", hash = "sha256:61717a1095d7e155cdb737ac7bb2f4324a858a1e2e6466f6d03ff630ca68d3cc"},
+    {file = "urllib3-1.26.16-py2.py3-none-any.whl", hash = "sha256:8d36afa7616d8ab714608411b4a3b13e58f463aee519024578e062e141dce20f"},
+    {file = "urllib3-1.26.16.tar.gz", hash = "sha256:8f135f6502756bde6b2a9b28989df5fbe87c9970cecaa69041edcce7f0589b14"},
 ]
 
 [package.extras]
-brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
-secure = ["certifi", "cryptography (>=1.9)", "idna (>=2.0.0)", "pyopenssl (>=17.1.0)", "urllib3-secure-extra"]
-socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
-zstd = ["zstandard (>=0.18.0)"]
+brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "zipp"
@@ -905,4 +904,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7,<3.12"
-content-hash = "5cb535c853d7233ac226c8ea2e50ca05ee7243bfb81ce72f76e93be3f56d1e7f"
+content-hash = "ca732947ba4a2d16d4697a43b8c81c77cf2f9b73892ba7f8fa80c43703ec8b0b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ arrow = ">=0.17.0,<0.18.0"
 binaryornot = ">=0.4.4,<0.5.0"
 texttable = ">=1.6.7,<1.7.0"
 requests = ">=2.24,<3.0"
-urllib3 = "1.26.16"  # lock v1 to avoid issues with openssl and old Python version (<3.9.11) on macOS
+urllib3 = "1.26.16"  # lock v1 to avoid issues with openssl and old Python versions (<3.9.11) on macOS
 
 [tool.poetry.group.test.dependencies]
 mock = ">=4.0.3,<4.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ arrow = ">=0.17.0,<0.18.0"
 binaryornot = ">=0.4.4,<0.5.0"
 texttable = ">=1.6.7,<1.7.0"
 requests = ">=2.24,<3.0"
+urllib3 = "1.26.16"  # lock v1 to avoid issues with openssl and old Python version (<3.9.11) on macOS
 
 [tool.poetry.group.test.dependencies]
 mock = ">=4.0.3,<4.1.0"


### PR DESCRIPTION
lock v1 to avoid issues with openssl and old Python versions (<3.9.11) on macOS