### PR TITLE
CM-26497 - Attach signed executables and their checksums as assets to GitHub releases

### DIFF
--- a/.github/workflows/build_executable.yml
+++ b/.github/workflows/build_executable.yml
@@ -1,9 +1,13 @@
-name: Build executable version of CLI
+name: Build executable version of CLI and upload artifact. On dispatch event build the latest tag and upload to release assets
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
+
+permissions:
+  contents: write
 
 jobs:
   build:
@@ -32,9 +36,16 @@ jobs:
             pypi.org
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Checkout latest release tag
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
+          git checkout $LATEST_TAG
+          echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_ENV
 
       - name: Set up Python 3.7
         uses: actions/setup-python@v4
@@ -67,7 +78,7 @@ jobs:
         run: ./dist/cycode version
 
       - name: Sign macOS executable
-        if: ${{ startsWith(matrix.os, 'macos') }}
+        if: runner.os == 'macOS'
         env:
           APPLE_CERT: ${{ secrets.APPLE_CERT }}
           APPLE_CERT_PWD: ${{ secrets.APPLE_CERT_PWD }}
@@ -92,7 +103,7 @@ jobs:
           codesign --deep --force --options=runtime --entitlements entitlements.plist --sign "$APPLE_CERT_NAME" --timestamp dist/cycode
 
       - name: Notarize macOS executable
-        if: ${{ startsWith(matrix.os, 'macos') }}
+        if: runner.os == 'macOS'
         env:
           APPLE_NOTARIZATION_EMAIL: ${{ secrets.APPLE_NOTARIZATION_EMAIL }}
           APPLE_NOTARIZATION_PWD: ${{ secrets.APPLE_NOTARIZATION_PWD }}
@@ -111,11 +122,11 @@ jobs:
           # xcrun stapler staple dist/cycode
 
       - name: Test macOS signed executable
-        if: ${{ startsWith(matrix.os, 'macos') }}
+        if: runner.os == 'macOS'
         run: ./dist/cycode version
 
       - name: Import cert for Windows and setup envs
-        if: ${{ startsWith(matrix.os, 'windows') }}
+        if: runner.os == 'Windows'
         env:
           SM_CLIENT_CERT_FILE_B64: ${{ secrets.SM_CLIENT_CERT_FILE_B64 }}
         run: |
@@ -128,7 +139,7 @@ jobs:
           echo "C:\Program Files\DigiCert\DigiCert One Signing Manager Tools" >> $GITHUB_PATH 
 
       - name: Sign Windows executable
-        if: ${{ startsWith(matrix.os, 'windows') }}
+        if: runner.os == 'Windows'
         shell: cmd
         env:
           SM_HOST: ${{ secrets.SM_HOST }}
@@ -146,7 +157,7 @@ jobs:
           signtool.exe sign /sha1 %SM_CODE_SIGNING_CERT_SHA1_HASH% /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 ".\dist\cycode.exe" 
 
       - name: Test Windows signed executable
-        if: ${{ startsWith(matrix.os, 'windows') }}
+        if: runner.os == 'Windows'
         shell: cmd
         run: |
           :: call executable and expect correct output
@@ -155,7 +166,41 @@ jobs:
           :: verify signature
           signtool.exe verify /v /pa ".\dist\cycode.exe"
 
-      - uses: actions/upload-artifact@v3
+      - name: Prepare files on Windows
+        if: runner.os == 'Windows'
+        run: |
+          echo "ARTIFACT_NAME=cycode-win" >> $GITHUB_ENV
+          mv dist/cycode.exe dist/cycode-win.exe
+          powershell -Command "(Get-FileHash -Algorithm SHA256 dist/cycode-win.exe).Hash" > sha256
+          head -c 64 sha256 > dist/cycode-win.exe.sha256
+
+      - name: Prepare files on macOS
+        if: runner.os == 'macOS'
+        run: |
+          echo "ARTIFACT_NAME=cycode-mac" >> $GITHUB_ENV
+          mv dist/cycode dist/cycode-mac
+          shasum -a 256 dist/cycode-mac > sha256
+          head -c 64 sha256 > dist/cycode-mac.sha256
+
+      - name: Prepare files on Linux
+        if: runner.os == 'Linux'
+        run: |
+          echo "ARTIFACT_NAME=cycode-linux" >> $GITHUB_ENV
+          mv dist/cycode dist/cycode-linux
+          sha256sum dist/cycode-linux > sha256
+          head -c 64 sha256 > dist/cycode-linux.sha256
+
+      - name: Upload files as artifact
+        uses: actions/upload-artifact@v3
         with:
-          name: cycode-cli-${{ matrix.os }}
+          name: ${{ env.ARTIFACT_NAME }}
           path: dist
+
+      - name: Upload files to release
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file: dist/*
+          tag: ${{ env.LATEST_TAG }}
+          overwrite: true
+          file_glob: true


### PR DESCRIPTION
DEMO:
![image](https://github.com/cycodehq-public/cycode-cli/assets/15520314/6211775d-c5a7-4246-9e1e-da590bf25560)
